### PR TITLE
Quick return if there are no require() calls - greatly speeds up parsing 

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var exports = module.exports = function (src) {
 
 exports.find = function (src) {
     var modules = { strings : [], expressions : [] };
+
+    if (src.indexOf('require(') == -1) return modules;
     
     burrito(src, function (node) {
         var isRequire = node.name === 'call'


### PR DESCRIPTION
Quick return if there are no require() calls - greatly speeds up parsing files like jQuery. 
