### PR TITLE
Performance boost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name" : "detective",
     "description" : "Find all calls to require() no matter how crazily nested using a proper walk of the AST",
-    "version" : "0.0.4",
+    "version" : "0.0.5",
     "repository" : {
         "type" : "git",
         "url" : "git://github.com/substack/node-detective.git"
@@ -22,7 +22,7 @@
         "test" : "expresso"
     },
     "dependencies" : {
-        "burrito" : "0.2.x"
+        "uglify-js" : "1.x"
     },
     "devDependencies" : {
         "expresso" : "=0.7.x"


### PR DESCRIPTION
I've decided to get rid of both `js-traverse` and `burrito` and use raw `uglify-js` instead. The thing is both js-traverse and burrito are too powerful, having too many features that are unused in detective - making it slow.

I think this solution is better than fixing js-traverse because someone might need those features and will use those projects, but in current situation it would be more time-consuming to try to make them even more generic and optimized, than to just use straight uglify. Hope you agree.

In detective all tests pass. In browserify `npm test` throws lots of errors with and without this patch (hope its a problem in my environment).

P.S. The code in traverse function is not generic, but as we only have AST tree here - it should be enough (and fast).
