### PR TITLE
Allow passing isRequire detector as an option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ exports.find = function (src, opts) {
     if (typeof src !== 'string') src = String(src);
     src = '(function(){' + src.replace(/^#![^\n]*\n/, '') + '\n})()';
     
-    function isRequire (node) {
+    var isRequire = opts.isRequire || function (node) {
         var c = node.callee;
         return c
             && node.type === 'CallExpression'

--- a/test/files/isrequire.js
+++ b/test/files/isrequire.js
@@ -1,0 +1,14 @@
+var a = require.async('a');
+var b = require.async('b');
+var c = require.async('c');
+var abc = a.b(c);
+
+var EventEmitter = require.async('events').EventEmitter;
+
+var x = require.async('doom')(5,6,7);
+x(8,9);
+c.load('notthis');
+var y = require.async('y') * 100;
+
+var EventEmitter2 = require.async('events2').EventEmitter();
+

--- a/test/isrequire.js
+++ b/test/isrequire.js
@@ -1,0 +1,20 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/isrequire.js');
+
+test('word', function (t) {
+    t.deepEqual(
+        detective(src, { isRequire: function(node) {
+          return (node.type === 'CallExpression' &&
+              node.callee.type === 'MemberExpression' &&
+              node.callee.object.type == 'Identifier' &&
+              node.callee.object.name == 'require' &&
+              node.callee.property.type == 'Identifier' &&
+              node.callee.property.name == 'async')
+        } }),
+        [ 'a', 'b', 'c', 'events', 'doom', 'y', 'events2' ]
+    );
+    t.end();
+});
+


### PR DESCRIPTION
I develop async loading mechanism on top of browserify modules and I'm using `require.async(id, callback)` syntax as async dependency declarations. That patch would allow me to reuse `detective` code to extract such dependencies.

It's not desirable for me to use `word` option cause that way I would need to introduce new "global" and thus become incompatibe with `browser-pack` which only passes `module`, `require` and `exports` to a module.
