### PR TITLE
Support require statements in code with ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima');
+var esprima = require('esprima-six');
 var escodegen = require('escodegen');
 
 var traverse = function (node, cb) {
@@ -12,7 +12,7 @@ var traverse = function (node, cb) {
     }
     else if (node && typeof node === 'object') {
         cb(node);
-        
+
         Object.keys(node).forEach(function (key) {
             if (key === 'parent' || !node[key]) return;
             node[key].parent = node;
@@ -38,7 +38,7 @@ exports.find = function (src, opts) {
     var word = opts.word === undefined ? 'require' : opts.word;
     if (typeof src !== 'string') src = String(src);
     src = src.replace(/^#![^\n]*\n/, '');
-    
+
     var isRequire = opts.isRequire || function (node) {
         var c = node.callee;
         return c
@@ -47,12 +47,12 @@ exports.find = function (src, opts) {
             && c.name === word
         ;
     }
-    
+
     var modules = { strings : [], expressions : [] };
     if (opts.nodes) modules.nodes = [];
-    
+
     if (src.indexOf(word) == -1) return modules;
-    
+
     walk(src, opts.parse, function (node) {
         if (!isRequire(node)) return;
         if (node.arguments.length
@@ -64,6 +64,6 @@ exports.find = function (src, opts) {
         }
         if (opts.nodes) modules.nodes.push(node);
     });
-    
+
     return modules;
 };

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-    "name" : "detective",
-    "description" : "find all require() calls by walking the AST",
-    "version" : "2.3.0",
-    "repository" : {
-        "type" : "git",
-        "url" : "git://github.com/substack/node-detective.git"
-    },
-    "main" : "index.js",
-    "keywords" : [
-        "require",
-        "source",
-        "analyze",
-        "ast"
-    ],
-    "scripts" : {
-        "test" : "tap test/*.js"
-    },
-    "dependencies" : {
-        "esprima" : "1.0.2",
-        "escodegen": "0.0.15"
-    },
-    "devDependencies" : {
-        "tap" : "~0.4.0"
-    },
-    "license" : "MIT",
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    }
+  "name": "detective",
+  "description": "find all require() calls by walking the AST",
+  "version": "2.3.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/node-detective.git"
+  },
+  "main": "index.js",
+  "keywords": [
+    "require",
+    "source",
+    "analyze",
+    "ast"
+  ],
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "dependencies": {
+    "escodegen": "0.0.15",
+    "esprima-six": "0.0.3"
+  },
+  "devDependencies": {
+    "tap": "~0.4.0"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  }
 }

--- a/test/files/generators.js
+++ b/test/files/generators.js
@@ -1,0 +1,5 @@
+var a = require('a');
+
+function *gen() {
+  yield require('b');
+}

--- a/test/files/yield.js
+++ b/test/files/yield.js
@@ -1,0 +1,2 @@
+var a = require('a');
+var b = yield require('c')(a);

--- a/test/generators.js
+++ b/test/generators.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/generators.js');
+
+test('generators', function (t) {
+    t.plan(1);
+    t.deepEqual(detective(src), [ 'a', 'b' ]);
+});

--- a/test/yield.js
+++ b/test/yield.js
@@ -1,0 +1,9 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+var src = fs.readFileSync(__dirname + '/files/yield.js');
+
+test('yield', function (t) {
+    t.plan(1);
+    t.deepEqual(detective(src), [ 'a', 'c' ]);
+});


### PR DESCRIPTION
Because the current version of node-detective uses the esprima module, and not the esprima-six module it crashes when it encounters ES6 specific syntax, e.g. stars in generator functions and the yield keyword.

It would be great if this could be added! :)
