### PR TITLE
remove esprima-six, go back to esprima

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima-six');
+var esprima = require('esprima');
 var escodegen = require('escodegen');
 
 var traverse = function (node, cb) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "escodegen": "~1.1.0",
-    "esprima-six": "0.0.3"
+    "esprima": "~1.0.4"
   },
   "devDependencies": {
     "tap": "~0.4.0"

--- a/test/generators.js
+++ b/test/generators.js
@@ -1,9 +1,0 @@
-var test = require('tap').test;
-var detective = require('../');
-var fs = require('fs');
-var src = fs.readFileSync(__dirname + '/files/generators.js');
-
-test('generators', function (t) {
-    t.plan(1);
-    t.deepEqual(detective(src), [ 'a', 'b' ]);
-});

--- a/test/yield.js
+++ b/test/yield.js
@@ -1,9 +1,0 @@
-var test = require('tap').test;
-var detective = require('../');
-var fs = require('fs');
-var src = fs.readFileSync(__dirname + '/files/yield.js');
-
-test('yield', function (t) {
-    t.plan(1);
-    t.deepEqual(detective(src), [ 'a', 'c' ]);
-});


### PR DESCRIPTION
`esprima-six` introduces regressions that break the browserifying of modules that used to work before the switch away from `esprima`, e.g.

```
$ browserify -r escodegen
SyntaxError: Line 819: Unexpected string while parsing /Users/maxypoo/src/node_modules/escodegen/escodegen.js
```

```
$ browserify -r detective
SyntaxError: Line 1460: Unexpected string while parsing /Users/maxypoo/src/node_modules/detective/node_modules/escodegen/escodegen.js
```

```
Error: Parsing file /tmp/glsl-parser11424-6356-1jwtxly/node_modules/glsl-parser/lib/index.js: Line 73: Comprehension Error
```

as stated by @thlorenz:

```
< thlorenz> better to have stable ES5 parsing than ES6 features (especially if there is always es6ify)
```

so this PR reverts back to `esprima`
