### PR TITLE
Use esprima-fb to support es6.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var esprima = require('esprima');
+var esprima = require('esprima-fb');
 var escodegen = require('escodegen');
 
 var traverse = function (node, cb) {
@@ -34,11 +34,11 @@ exports.find = function (src, opts) {
     if (!opts) opts = {};
     opts.parse = opts.parse || {};
     opts.parse.tolerant = true;
-    
+
     var word = opts.word === undefined ? 'require' : opts.word;
     if (typeof src !== 'string') src = String(src);
     src = src.replace(/^#![^\n]*\n/, '');
-    
+
     var isRequire = opts.isRequire || function (node) {
         var c = node.callee;
         return c
@@ -47,12 +47,12 @@ exports.find = function (src, opts) {
             && c.name === word
         ;
     }
-    
+
     var modules = { strings : [], expressions : [] };
     if (opts.nodes) modules.nodes = [];
-    
+
     if (src.indexOf(word) == -1) return modules;
-    
+
     walk(src, opts.parse, function (node) {
         if (!isRequire(node)) return;
         if (node.arguments.length) {
@@ -65,6 +65,6 @@ exports.find = function (src, opts) {
         }
         if (opts.nodes) modules.nodes.push(node);
     });
-    
+
     return modules;
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "escodegen": "~1.1.0",
-    "esprima": "~1.0.4"
+    "esprima-fb": "^3001.1.0-dev-harmony-fb"
   },
   "devDependencies": {
     "tap": "~0.4.0"


### PR DESCRIPTION
esprima-fb is used over a yeat in production at Facebook in their es6-to-es5 code transforms so I think it could be considered robust.
