### PR TITLE
[draft] ES6 import support

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # detective
 
-find all calls to `require()` by walking the AST
+find all calls to `require()` or ES6 `import` by walking the AST
 
 [![build status](https://secure.travis-ci.org/substack/node-detective.png)](http://travis-ci.org/substack/node-detective)
 
@@ -66,6 +66,16 @@ node is a require call
 * `opts.parse` - supply options directly to
 [acorn](https://npmjs.org/package/acorn) with some support for esprima-style
 options `range` and `loc`
+
+## ES6
+
+The following option will also search for ES6 `import` statements.
+
+```js
+var imports = detective(source, {
+  parse: { sourceType: 'module', ecmaVersion: 6 }
+})
+```
 
 # install
 

--- a/test/es6-module.js
+++ b/test/es6-module.js
@@ -5,5 +5,7 @@ var src = fs.readFileSync(__dirname + '/files/es6-module.js');
 
 test('es6-module', function (t) {
     t.plan(1);
-    t.deepEqual(detective(src, {parse: {sourceType: 'module'}}), [ 'a', 'b' ]);
+    t.deepEqual(detective(src, {
+      parse: { sourceType: 'module', ecmaVersion: 6 }
+    }), [ 'a', './foo', './blah', 'lodash', 'defaults', 'side-effects', 'b' ]);
 });

--- a/test/files/es6-module.js
+++ b/test/files/es6-module.js
@@ -1,4 +1,9 @@
 var a = require('a');
+import { foo } from './foo';
+import { foo as blah } from './blah';
+import * as _ from 'lodash';
+import defs from 'defaults';
+import 'side-effects';
 
 export default function () {
     var b = require('b');


### PR DESCRIPTION
Fixes #56 and allows for detective to find `import` statements.

Note there is also [detective-es6](https://github.com/mrjoelkemp/node-detective-es6) which is probably better suited for common situations, since it doesn't consider `require` calls.
