### PR TITLE
Drastically reduce the cost of walking the AST

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,18 @@ exports.find = function (src, opts) {
                     // Continue traversing the children of this node.
                     var keys = Object.keys(node);
                     for (var i = 0, len = keys.length; i < len; ++i) {
-                        walk(node[keys[i]], left, right);
+                        var key = keys[i];
+
+                        switch (key) {
+                        case "type":
+                        case "loc":
+                        case "start":
+                        case "end":
+                            // Ignore common keys that are never nodes.
+                            continue;
+                        }
+
+                        walk(node[key], left, right);
                     }
 
                     return;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var acorn = require('acorn');
-var escodegen = require('escodegen');
 var defined = require('defined');
 var hasOwn = Object.prototype.hasOwnProperty;
 var cachedRegExps = {
@@ -105,7 +104,7 @@ exports.find = function (src, opts) {
                             typeof arg.value === "string") {
                             modules.strings.push(arg.value);
                         } else {
-                            modules.expressions.push(escodegen.generate(arg));
+                            modules.expressions.push(src.slice(arg.start, arg.end));
                         }
                     }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "dependencies": {
     "acorn": "^1.0.3",
-    "defined": "^1.0.0",
-    "escodegen": "^1.4.1"
+    "defined": "^1.0.0"
   },
   "devDependencies": {
     "tap": "^1.0.0"

--- a/test/files/both.js
+++ b/test/files/both.js
@@ -1,4 +1,4 @@
 require('a');
 require('b');
-require('c'+x);
-var moo = require('d'+y).moo;
+require('c' + x);
+var moo = require('d' + y).moo;


### PR DESCRIPTION
Before these changes, traversing the [jQuery](http://code.jquery.com/jquery-2.1.4.js) AST using `walk.simple` used to take ~15ms on my machine. Now, the `walk` function takes 0.03ms.

The trick is to scan the `source` string to find all possible positions of `require` tokens using the `wordRe` regular expression, then use those positions to guide the traversal, so that entire subtrees can be ignored if they do not contain any `require` tokens.

Parsing the code still takes the majority of the time (~70ms for jQuery), but the AST traversal savings definitely add up when browserifying large projects.

I also took this opportunity to add support for ES2015 `import` statements (and `export...from` statements, too): https://github.com/benjamn/node-detective/commit/2249f98405fc7549d66b4b6101286d157e6f88eb, though I'd be happy to split that out into a separate pull request (or contribute to #57) if you prefer.
