### PR TITLE
Use acorn-node defaults for syntax options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,20 +6,20 @@ var requireRe = /\brequire\b/;
 
 function parse (src, opts) {
     if (!opts) opts = {};
-    return acorn.parse(src, {
-        ecmaVersion: defined(opts.ecmaVersion, 9),
-        sourceType: defined(opts.sourceType, 'script'),
+    var acornOpts = {
         ranges: defined(opts.ranges, opts.range),
         locations: defined(opts.locations, opts.loc),
         allowReserved: defined(opts.allowReserved, true),
-        allowReturnOutsideFunction: defined(
-            opts.allowReturnOutsideFunction, true
-        ),
-        allowImportExportEverywhere: defined(
-            opts.allowImportExportEverywhere, true
-        ),
-        allowHashBang: defined(opts.allowHashBang, true)
-    });
+        allowImportExportEverywhere: defined(opts.allowImportExportEverywhere, false)
+    };
+
+    // Use acorn-node's defaults for the rest.
+    if (opts.ecmaVersion != null) acornOpts.ecmaVersion = opts.ecmaVersion;
+    if (opts.sourceType != null) acornOpts.sourceType = opts.sourceType;
+    if (opts.allowHashBang != null) acornOpts.allowHashBang = opts.allowHashBang;
+    if (opts.allowReturnOutsideFunction != null) acornOpts.allowReturnOutsideFunction = opts.allowReturnOutsideFunction;
+
+    return acorn.parse(src, acornOpts);
 }
 
 var exports = module.exports = function (src, opts) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bin": "bin/detective.js",
   "dependencies": {
-    "acorn-node": "^1.3.0",
+    "acorn-node": "^1.6.1",
     "defined": "^1.0.0",
     "minimist": "^1.1.1"
   },

--- a/test/es2019.js
+++ b/test/es2019.js
@@ -1,0 +1,15 @@
+var test = require('tap').test;
+var detective = require('../');
+var fs = require('fs');
+
+test('es2019 - for-await', function (t) {
+    var src = fs.readFileSync(__dirname + '/files/for-await.js');
+    t.doesNotThrow(detective.bind(detective, src), 'Files with `for await()` do not throw')
+    t.end();
+});
+
+test('es2019 - optional-catch', function (t) {
+    var src = fs.readFileSync(__dirname + '/files/optional-catch.js');
+    t.doesNotThrow(detective.bind(detective, src), 'Files with omitted catch binding do not throw')
+    t.end();
+});

--- a/test/files/for-await.js
+++ b/test/files/for-await.js
@@ -1,0 +1,5 @@
+async function main () {
+    for await (const _ of (async function* () {})()) {
+        require(_)
+    }
+}

--- a/test/files/optional-catch.js
+++ b/test/files/optional-catch.js
@@ -1,0 +1,4 @@
+try {
+    require;
+} catch {
+}


### PR DESCRIPTION
acorn-node tries to sync its `ecmaVersion` and such with Node.js. We can
just rely on it to fill in the default value so we don't have to
manually update detective to match.

This adds support for optional catch bindings which are an ES2019
(`ecmaVersion: 10`) feature.